### PR TITLE
Multiple mosaics

### DIFF
--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -95,6 +95,10 @@ def main(argv):
     log.info('Checking for images and beams')
     make_mosaic.final_check_for_files(input_dir, images, beams)  # This function raises an error and exits if files are not found
 
+    if args.associated_mosaics:  # Want to be sure that all of the ingredients are in place before doing any mosaicking
+        log.info('Checking for models and residuals')
+        make_mosaic.final_check_for_files(input_dir, models, residuals)  # Function raises an error and should exit if files are not found
+
     if args.force_regrid:
         log.info('You have asked for all regridded files to be created by this run, even if they are already on disk') 
         make_mosaic.use_montage_for_regridding(
@@ -127,9 +131,6 @@ def main(argv):
 
 
     if args.associated_mosaics:  # Code is more readable by keeping these mosaics separate
-
-        log.info('Checking for models and residuals')
-        make_mosaic.final_check_for_files(input_dir, models, residuals)  # This function raises an error and exits if files are not found
 
         if args.force_regrid:
             log.info('You have asked for all regridded files to be created by this run, even if they are already on disk')

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -126,7 +126,8 @@ def main(argv):
 
         make_mosaic.check_for_regridded_files(output_dir, modelsR, residualsR)
 
-        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname, imagesR, beamsR, cutoff, images)
+        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname, modelsR, beamsR, cutoff, models)
+        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname, residualsR, beamsR, cutoff, residuals)
 
     # Move the log file to the output directory
     os.system('mv log-make_mosaic.txt '+output_dir+'/')

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -125,7 +125,7 @@ def main(argv):
                 'Will use regridded models and residuals available on disc'.format(outname))
 
         make_mosaic.check_for_regridded_files(output_dir, modelsR, residualsR)
-
+        
         make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname+'_model', modelsR, beamsR, cutoff, models)
         make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname+'_residual', residualsR, beamsR, cutoff, residuals)
 

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -124,8 +124,7 @@ def main(argv):
     else:
         log.info(
             'Will use mosaic header {0:s}.hdr and regridded images and beams available on disk'.format(outname))
-
-    make_mosaic.final_check_for_files(output_dir, imagesR, beamsR)  # This function raises an error and exits if files are not found 
+        make_mosaic.final_check_for_files(output_dir, imagesR, beamsR)  # This function raises an error and exits if files are not found 
 
     make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'image', outname, imagesR, beamsR, cutoff, images)
 
@@ -157,8 +156,7 @@ def main(argv):
         else:
             log.info(
                 'Will use regridded models and residuals available on disk'.format(outname))
-
-        make_mosaic.final_check_for_files(output_dir, modelsR, residualsR)
+            make_mosaic.final_check_for_files(output_dir, modelsR, residualsR)
 
         make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'model', outname, modelsR, beamsR, cutoff, models)
         make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'residual', outname, residualsR, beamsR, cutoff, residuals)

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -98,23 +98,27 @@ def main(argv):
     if args.force_regrid:
         log.info('You have asked for all regridded files to be created by this run, even if they are already on disk') 
         make_mosaic.use_montage_for_regridding(
-            input_dir, output_dir, mosaic_type, 'image', images, beams, imagesR, beamsR, outname)
+            input_dir, output_dir, mosaic_type, 'image', images, imagesR, beams, beamsR, outname)
+        make_mosaic.use_montage_for_regridding(
+            input_dir, output_dir, mosaic_type, 'pb', images, imagesR, beams, beamsR, outname)
     if args.regrid:
         log.info('Checking for regridded images and beams')
         imagesR_dont_exist = check_for_files(output_dir, imagesR)
         if imagesR_dont_exist:
             log.info('Regridded images are not all in place, so using montage to create them')
             make_mosaic.use_montage_for_regridding(
-                input_dir, output_dir, mosaic_type, 'image', images, beams, imagesR, beamsR, outname)
+                input_dir, output_dir, mosaic_type, 'image', images, imagesR, beams, beamsR, outname)
         beamsR_dont_exist = check_for_files(output_dir, beamsR)
         if beamsR_dont_exist:  
             log.info('Regridded beams are not all in place, so using montage to create them')
             make_mosaic.use_montage_for_regridding(
-                input_dir, output_dir, mosaic_type, 'pb', images, beams, imagesR, beamsR, outname)
+                input_dir, output_dir, mosaic_type, 'pb', images, imagesR, beams, beamsR, outname)
     else:
         log.info(
             'Will use mosaic header {0:s}.hdr and regridded images and beams available on disk'.format(outname))
 
+    exit() ### CHECK REGRIDDING IS STILL WORKING BEFORE PROCEEDING 
+    
     make_mosaic.final_check_for_files(output_dir, imagesR, beamsR)  # This function raises an error and exits if files are not found 
 
     make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'image', outname, imagesR, beamsR, cutoff, images)

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -109,7 +109,7 @@ def main(argv):
 
     make_mosaic.check_for_regridded_files(output_dir, imagesR, beamsR)
 
-    make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname, imagesR, beamsR, cutoff, images)
+    make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'image', outname, imagesR, beamsR, cutoff, images)
 
     if args.associated_mosaics:
 
@@ -125,9 +125,9 @@ def main(argv):
                 'Will use regridded models and residuals available on disc'.format(outname))
 
         make_mosaic.check_for_regridded_files(output_dir, modelsR, residualsR)
-        
-        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname+'_model', modelsR, beamsR, cutoff, models)
-        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname+'_residual', residualsR, beamsR, cutoff, residuals)
+
+        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'model', outname+'_model', modelsR, beamsR, cutoff, models)
+        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'residual', outname+'_residual', residualsR, beamsR, cutoff, residuals)
 
     # Move the log file to the output directory
     os.system('mv log-make_mosaic.txt '+output_dir+'/')

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -90,23 +90,11 @@ def main(argv):
     else:
         log.info('Will generate a mosaic from the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the "associated_mosaics" parameter enabled.')
 
-    check_for_files(input_dir, images)
-    #for tt in images:
-    #    try:
-    #        open(input_dir+'/'+tt)
-    #    except FileNotFoundError:
-    #        log.error('File {0:s} does not exist'.format(input_dir+'/'+tt))
-    #        raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+tt))
-    check_for_files(input_dir, beams)
-    #for bb in beams:
-    #    try:
-    #        open(input_dir+'/'+bb)
-    #    except FileNotFoundError:
-    #        log.error('File {0:s} does not exist'.format(input_dir+'/'+bb)) 
-    #        raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+bb))
-    log.info('All images and beams found on disc')
+    log.info('Checking for images and beams')
+    make_mosaic.final_check_for_files(input_dir, images, beams)  # This function raises an error and exits if files are not found
 
     if args.force_regrid:
+        log.info('User wants all regridded files to be created by this run, even if they are already on disk') 
         make_mosaic.use_montage_for_regridding(
             input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
     if args.regrid:
@@ -114,13 +102,14 @@ def main(argv):
         check_for_files(output_dir, imagesR)
         check_for_files(output_dir, beamsR)
         if exists == False:
+            log.info('They are not all in place, so using montage to create them')
             make_mosaic.use_montage_for_regridding(
                 input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
     else:
         log.info(
-            'Will use mosaic header {0:s}.hdr and regridded images and beams available on disc'.format(outname))
+            'Will use mosaic header {0:s}.hdr and regridded images and beams available on disk'.format(outname))
 
-    make_mosaic.final_check_for_regridded_files(output_dir, imagesR, beamsR)  # This function raises an error and exits if files are not found 
+    make_mosaic.final_check_for_files(output_dir, imagesR, beamsR)  # This function raises an error and exits if files are not found 
 
     make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'image', outname, imagesR, beamsR, cutoff, images)
 
@@ -128,7 +117,7 @@ def main(argv):
 
         check_for_files(input_dir, models)
         check_for_files(input_dir, residuals)
-        log.info('All models and residuals found on disc')
+        log.info('All models and residuals found on disk')
 
         if args.regrid:
             make_mosaic.use_montage_for_regridding(

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -90,7 +90,7 @@ def main(argv):
         residuals = [tt.replace('image.fits', 'residual.fits') for tt in images]
         residualsR = [tt.replace('image.fits', 'residualR.fits') for tt in images]
     else:
-        log.info('Will generate a mosaic from the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the "--associated-mosaics" argument enabled.')
+        log.info("Will generate a mosaic from the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the '--associated-mosaics' argument enabled.")
 
     log.info('Checking for images and beams')
     make_mosaic.final_check_for_files(input_dir, images, beams)  # This function raises an error and exits if files are not found
@@ -101,7 +101,7 @@ def main(argv):
             input_dir, output_dir, mosaic_type, 'image', images, imagesR, beams, beamsR, outname)
         make_mosaic.use_montage_for_regridding(
             input_dir, output_dir, mosaic_type, 'pb', images, imagesR, beams, beamsR, outname)
-    if args.regrid:
+    elif args.regrid:
         log.info('Checking for regridded images and beams')
         imagesR_dont_exist = check_for_files(output_dir, imagesR)
         if imagesR_dont_exist:

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -126,8 +126,8 @@ def main(argv):
 
         make_mosaic.check_for_regridded_files(output_dir, modelsR, residualsR)
 
-        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname, modelsR, beamsR, cutoff, models)
-        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname, residualsR, beamsR, cutoff, residuals)
+        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname+'_model', modelsR, beamsR, cutoff, models)
+        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname+'_residual', residualsR, beamsR, cutoff, residuals)
 
     # Move the log file to the output directory
     os.system('mv log-make_mosaic.txt '+output_dir+'/')

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -98,15 +98,19 @@ def main(argv):
     if args.force_regrid:
         log.info('You have asked for all regridded files to be created by this run, even if they are already on disk') 
         make_mosaic.use_montage_for_regridding(
-            input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
+            input_dir, output_dir, mosaic_type, 'image', images, beams, imagesR, beamsR, outname)
     if args.regrid:
         log.info('Checking for regridded images and beams')
         imagesR_dont_exist = check_for_files(output_dir, imagesR)
-        beamsR_dont_exist = check_for_files(output_dir, beamsR)
-        if imagesR_dont_exist or beamsR_dont_exist:  # If EITHER of these is True, do some regridding
-            log.info('They are not all in place, so using montage to create them')
+        if imagesR_dont_exist:
+            log.info('Regridded images are not all in place, so using montage to create them')
             make_mosaic.use_montage_for_regridding(
-                input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
+                input_dir, output_dir, mosaic_type, 'image', images, beams, imagesR, beamsR, outname)
+        beamsR_dont_exist = check_for_files(output_dir, beamsR)
+        if beamsR_dont_exist:  
+            log.info('Regridded beams are not all in place, so using montage to create them')
+            make_mosaic.use_montage_for_regridding(
+                input_dir, output_dir, mosaic_type, 'pb', images, beams, imagesR, beamsR, outname)
     else:
         log.info(
             'Will use mosaic header {0:s}.hdr and regridded images and beams available on disk'.format(outname))

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -121,8 +121,6 @@ def main(argv):
         log.info(
             'Will use mosaic header {0:s}.hdr and regridded images and beams available on disk'.format(outname))
 
-    exit() ### CHECK REGRIDDING IS STILL WORKING BEFORE PROCEEDING 
-    
     make_mosaic.final_check_for_files(output_dir, imagesR, beamsR)  # This function raises an error and exits if files are not found 
 
     make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'image', outname, imagesR, beamsR, cutoff, images)

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -21,15 +21,15 @@ except NameError:
 
 def check_for_files(input_dir, images):
 
-    exist = True 
+    dont_exist = False 
     for tt in images:
         try:
             open(input_dir+'/'+tt)
         except FileNotFoundError:
             log.error('File {0:s} does not exist'.format(input_dir+'/'+tt))
-            exist = False 
+            dont_exist = True 
 
-    return exist
+    return dont_exist
 
 
 def main(argv):
@@ -101,11 +101,9 @@ def main(argv):
             input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
     if args.regrid:
         log.info('Checking for regridded images and beams')
-        imagesR_exist = check_for_files(output_dir, imagesR)
-        beamsR_exist = check_for_files(output_dir, beamsR)
-        if imagesR_exist or beamsR_exist:
-
-        else:
+        imagesR_dont_exist = check_for_files(output_dir, imagesR)
+        beamsR_dont_exist = check_for_files(output_dir, beamsR)
+        if imagesR_dont_exist or beamsR_dont_exist:  # If EITHER of these is True, do some regridding
             log.info('They are not all in place, so using montage to create them')
             make_mosaic.use_montage_for_regridding(
                 input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -41,7 +41,11 @@ def main(argv):
                         help="Also make mosaics of the associated 'model' and 'residual' .fits files.")
     parser.add_argument("-r", "--regrid", action="store_true",
                         help="Use montage for regridding the images and beams."
-                              "Also the 'model' and 'residual' files, if '--associated-mosaics' has been enabled.")
+                              "Also regrid the 'model' and 'residual' files, if '--associated-mosaics' is enabled.")
+    parser.add_argument("-f", "--force-regrid", action="store_true",
+                        help="If the user wants newly-regridded files, this '--force-regrid' argument should be enabled."
+                              "If '--regrid' is enabled instead, the package will first check whether regridded files already exist." 
+                              "(If they are found, regridding will not proceed because this is a time-consuming step.")
     parser.add_argument("-c", "--cutoff", type=float, default=0.1,
                         help="The cutoff in the primary beam to use (assuming a Gaussian at the moment)."
                               "E.g. The default of 0.1 means going down to the 10 percent level for each pointing.")

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -129,7 +129,7 @@ def main(argv):
     if args.associated_mosaics:  # Code is more readable by keeping these mosaics separate
 
         log.info('Checking for models and residuals')
-        make_mosaic.final_check_for_files(input_dir, images, beams)  # This function raises an error and exits if files are not found
+        make_mosaic.final_check_for_files(input_dir, models, residuals)  # This function raises an error and exits if files are not found
 
         if args.force_regrid:
             log.info('You have asked for all regridded files to be created by this run, even if they are already on disk')

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -91,7 +91,6 @@ def main(argv):
     #    except FileNotFoundError:
     #        log.error('File {0:s} does not exist'.format(input_dir+'/'+tt))
     #        raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+tt))
-
     check_for_files(input_dir, beams)
     #for bb in beams:
     #    try:
@@ -99,18 +98,20 @@ def main(argv):
     #    except FileNotFoundError:
     #        log.error('File {0:s} does not exist'.format(input_dir+'/'+bb)) 
     #        raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+bb))
-
     log.info('All images and beams found on disc')
 
     if args.associated_mosaics:
 
-
+        check_for_files(input_dir, models)
+        check_for_files(input_dir, residuals)
         log.info('All models and residuals found on disc')
-
 
     if args.regrid:
         make_mosaic.use_montage_for_regridding(
             input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
+        if args.associated_mosaics:
+            make_mosaic.use_montage_for_regridding(
+                input_dir, output_dir, mosaic_type, models, residuals, modelsR, residualsR, outname)
     else:
         log.info(
             'Will use mosaic header {0:s}.hdr and regridded images and beams available on disc'.format(outname))

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -21,13 +21,15 @@ except NameError:
 
 def check_for_files(input_dir, images):
 
-    exists = True 
+    exist = True 
     for tt in images:
         try:
             open(input_dir+'/'+tt)
         except FileNotFoundError:
             log.error('File {0:s} does not exist'.format(input_dir+'/'+tt))
-            exists = False 
+            exist = False 
+
+    return exist
 
 
 def main(argv):
@@ -88,20 +90,22 @@ def main(argv):
         residuals = [tt.replace('image.fits', 'residual.fits') for tt in images]
         residualsR = [tt.replace('image.fits', 'residualR.fits') for tt in images]
     else:
-        log.info('Will generate a mosaic from the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the "associated_mosaics" parameter enabled.')
+        log.info('Will generate a mosaic from the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the "--associated_mosaics" argument enabled.')
 
     log.info('Checking for images and beams')
     make_mosaic.final_check_for_files(input_dir, images, beams)  # This function raises an error and exits if files are not found
 
     if args.force_regrid:
-        log.info('User wants all regridded files to be created by this run, even if they are already on disk') 
+        log.info('You have asked for all regridded files to be created by this run, even if they are already on disk') 
         make_mosaic.use_montage_for_regridding(
             input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
     if args.regrid:
-        log.info('Checking whether regridded images and beams already exist')
-        check_for_files(output_dir, imagesR)
-        check_for_files(output_dir, beamsR)
-        if exists == False:
+        log.info('Checking for regridded images and beams')
+        imagesR_exist = check_for_files(output_dir, imagesR)
+        beamsR_exist = check_for_files(output_dir, beamsR)
+        if imagesR_exist or beamsR_exist:
+
+        else:
             log.info('They are not all in place, so using montage to create them')
             make_mosaic.use_montage_for_regridding(
                 input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -74,10 +74,10 @@ def main(argv):
             "Must specify the (2D or 3D) images to be mosaicked, each prefixed by '-t '.")
         raise LookupError("Must specify the (2D or 3D) images to be mosaicked, each prefixed by '-t '.")
 
-    # Throw an error if the user provides only one image
-    if len(images) < 2:
-        log.error('At least two images must be specified for mosaicking')
-        raise ValueError('At least two images must be specified for mosaicking')
+    # # Throw an error if the user provides only one image
+    # if len(images) < 2:
+    #    log.error('At least two images must be specified for mosaicking')
+    #    raise ValueError('At least two images must be specified for mosaicking')
 
     # 'R' to signify the regridded versions of the different .fits files
     imagesR = [tt.replace('image.fits', 'imageR.fits') for tt in images]

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -44,8 +44,8 @@ def main(argv):
                               "Also regrid the 'model' and 'residual' files, if '--associated-mosaics' is enabled.")
     parser.add_argument("-f", "--force-regrid", action="store_true",
                         help="If the user wants newly-regridded files, this '--force-regrid' argument should be enabled."
-                              "If '--regrid' is enabled instead, the package will first check whether regridded files already exist." 
-                              "(If they are found, regridding will not proceed because this is a time-consuming step.")
+                              "(If '--regrid' is enabled instead, the package will first check whether regridded files already exist." 
+                              "If they are found, regridding will not proceed because this is a time-consuming step.)")
     parser.add_argument("-c", "--cutoff", type=float, default=0.1,
                         help="The cutoff in the primary beam to use (assuming a Gaussian at the moment)."
                               "E.g. The default of 0.1 means going down to the 10 percent level for each pointing.")
@@ -105,14 +105,20 @@ def main(argv):
     #        raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+bb))
     log.info('All images and beams found on disc')
 
-    if args.regrid:
+    if args.force_regrid:
         make_mosaic.use_montage_for_regridding(
             input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
+    if args.regrid:
+        log.info('Checking whether regridded images and beams already exist')
+        make_mosaic.check_for_regridded_files(output_dir, imagesR, beamsR)
+        # if they don't exist, only then
+            make_mosaic.use_montage_for_regridding(
+                input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
     else:
         log.info(
             'Will use mosaic header {0:s}.hdr and regridded images and beams available on disc'.format(outname))
 
-    make_mosaic.check_for_regridded_files(output_dir, imagesR, beamsR)
+    make_mosaic.check_for_regridded_files(output_dir, imagesR, beamsR)  # This function raises an error and exits if files are not found 
 
     make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'image', outname, imagesR, beamsR, cutoff, images)
 

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -158,7 +158,7 @@ def main(argv):
             log.info(
                 'Will use regridded models and residuals available on disk'.format(outname))
 
-        make_mosaic.check_for_regridded_files(output_dir, modelsR, residualsR)
+        make_mosaic.final_check_for_files(output_dir, modelsR, residualsR)
 
         make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'model', outname, modelsR, beamsR, cutoff, models)
         make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'residual', outname, residualsR, beamsR, cutoff, residuals)

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -19,6 +19,16 @@ try:
 except NameError:
     FileNotFoundError = IOError
 
+def check_for_files(input_dir, images):
+
+    for tt in images:
+        try:
+            open(input_dir+'/'+tt)
+        except FileNotFoundError:
+            log.error('File {0:s} does not exist'.format(input_dir+'/'+tt))
+            raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+tt))
+
+
 def main(argv):
 
     parser = ArgumentParser(description="Run make_mosaic over the targets")
@@ -89,6 +99,11 @@ def main(argv):
             raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+bb))
 
     log.info('All images and beams found on disc')
+
+    if args.associated_mosaics:
+
+
+        log.info('All models and residuals found on disc')
 
 
     if args.regrid:

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -26,7 +26,9 @@ def main(argv):
     parser.add_argument("-i", "--input",
                         help="The directory that contains the (2D or 3D) images and beams.")
     parser.add_argument("-m", "--mosaic-type",
-                        help="State 'continuum' or 'spectral' as the type of mosaic to be made.")
+                        help="State 'continuum' or 'spectral' as the type of (image) mosaic to be made.")
+    parser.add_argument("-a", "--associated-mosaics",
+                        help="Set to 'True' if mosaics of the 'residuals' and 'weights' are also to be made.")
     parser.add_argument("-r", "--regrid", action="store_true",
                         help="Use montage for regridding the images and beams.")
     parser.add_argument("-c", "--cutoff", type=float, default=0.1,

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -27,7 +27,7 @@ def main(argv):
                         help="The directory that contains the (2D or 3D) images and beams.")
     parser.add_argument("-m", "--mosaic-type",
                         help="State 'continuum' or 'spectral' as the type of mosaic to be made.")
-    parser.add_argument("-d", "--domontage", action="store_true",
+    parser.add_argument("-r", "--regrid", action="store_true",
                         help="Use montage for regridding the images and beams.")
     parser.add_argument("-c", "--cutoff", type=float, default=0.1,
                          help="The cutoff in the primary beam to use (assuming a Gaussian at the moment)."
@@ -80,7 +80,7 @@ def main(argv):
     log.info('All images and beams found on disc')
 
 
-    if args.domontage:
+    if args.regrid:
         make_mosaic.use_montage_for_regridding(
             input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
     else:

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -118,7 +118,7 @@ def main(argv):
         log.info(
             'Will use mosaic header {0:s}.hdr and regridded images and beams available on disc'.format(outname))
 
-    make_mosaic.check_for_regridded_files(output_dir, imagesR, beamsR)  # This function raises an error and exits if files are not found 
+    make_mosaic.final_check_for_regridded_files(output_dir, imagesR, beamsR)  # This function raises an error and exits if files are not found 
 
     make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'image', outname, imagesR, beamsR, cutoff, images)
 

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -61,14 +61,18 @@ def main(argv):
         log.error('At least two images must be specified for mosaicking')
         raise ValueError('At least two images must be specified for mosaicking')
 
+    # 'R' to signify the regridded versions of the different .fits files
     imagesR = [tt.replace('image.fits', 'imageR.fits') for tt in images]
     beams = [tt.replace('image.fits', 'pb.fits') for tt in images]
     beamsR = [tt.replace('image.fits', 'pbR.fits') for tt in images]
     if args.associated_mosaics:
-        log.info('Will generate mosaics based on the input images, their associated models, and their residuals') # Add 'weights' later once I know where it's come from
-        
+        log.info('Will generate mosaics made from the input images, their associated models, and their residuals')
+        models = [tt.replace('image.fits', 'model.fits') for tt in images]
+        modelsR = [tt.replace('image.fits', 'modelR.fits') for tt in images]
+        residuals = [tt.replace('image.fits', 'residual.fits') for tt in images]
+        residualsR = [tt.replace('image.fits', 'residualR.fits') for tt in images]
     else:
-        log.info('Will generate a mosaic based on the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the "associated_mosaics" parameter enabled.')
+        log.info('Will generate a mosaic from the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the "associated_mosaics" parameter enabled.')
 
     for tt in images:
         try:

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -164,6 +164,6 @@ def main(argv):
         make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'residual', outname, residualsR, beamsR, cutoff, residuals)
 
     # Move the log file to the output directory
-    os.system('mv log-make_mosaic.txt '+output_dir+'/')
+    os.system('mv log-make__mosaic.txt '+output_dir+'/')
 
     return 0

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -21,12 +21,13 @@ except NameError:
 
 def check_for_files(input_dir, images):
 
+    exists = True 
     for tt in images:
         try:
             open(input_dir+'/'+tt)
         except FileNotFoundError:
             log.error('File {0:s} does not exist'.format(input_dir+'/'+tt))
-            raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+tt))
+            exists = False 
 
 
 def main(argv):
@@ -110,8 +111,9 @@ def main(argv):
             input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
     if args.regrid:
         log.info('Checking whether regridded images and beams already exist')
-        make_mosaic.check_for_regridded_files(output_dir, imagesR, beamsR)
-        # if they don't exist, only then
+        check_for_files(output_dir, imagesR)
+        check_for_files(output_dir, beamsR)
+        if exists == False:
             make_mosaic.use_montage_for_regridding(
                 input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
     else:

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -90,7 +90,7 @@ def main(argv):
         residuals = [tt.replace('image.fits', 'residual.fits') for tt in images]
         residualsR = [tt.replace('image.fits', 'residualR.fits') for tt in images]
     else:
-        log.info('Will generate a mosaic from the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the "--associated_mosaics" argument enabled.')
+        log.info('Will generate a mosaic from the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the "--associated-mosaics" argument enabled.')
 
     log.info('Checking for images and beams')
     make_mosaic.final_check_for_files(input_dir, images, beams)  # This function raises an error and exits if files are not found

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -100,18 +100,9 @@ def main(argv):
     #        raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+bb))
     log.info('All images and beams found on disc')
 
-    if args.associated_mosaics:
-
-        check_for_files(input_dir, models)
-        check_for_files(input_dir, residuals)
-        log.info('All models and residuals found on disc')
-
     if args.regrid:
         make_mosaic.use_montage_for_regridding(
             input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname)
-        if args.associated_mosaics:
-            make_mosaic.use_montage_for_regridding(
-                input_dir, output_dir, mosaic_type, models, residuals, modelsR, residualsR, outname)
     else:
         log.info(
             'Will use mosaic header {0:s}.hdr and regridded images and beams available on disc'.format(outname))
@@ -119,6 +110,23 @@ def main(argv):
     make_mosaic.check_for_regridded_files(output_dir, imagesR, beamsR)
 
     make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname, imagesR, beamsR, cutoff, images)
+
+    if args.associated_mosaics:
+
+        check_for_files(input_dir, models)
+        check_for_files(input_dir, residuals)
+        log.info('All models and residuals found on disc')
+
+        if args.regrid:
+            make_mosaic.use_montage_for_regridding(
+                input_dir, output_dir, mosaic_type, models, residuals, modelsR, residualsR, outname)
+        else:
+            log.info(
+                'Will use regridded models and residuals available on disc'.format(outname))
+
+        make_mosaic.check_for_regridded_files(output_dir, modelsR, residualsR)
+
+        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, outname, imagesR, beamsR, cutoff, images)
 
     # Move the log file to the output directory
     os.system('mv log-make_mosaic.txt '+output_dir+'/')

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -125,18 +125,37 @@ def main(argv):
 
     make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'image', outname, imagesR, beamsR, cutoff, images)
 
-    if args.associated_mosaics:
 
-        check_for_files(input_dir, models)
-        check_for_files(input_dir, residuals)
-        log.info('All models and residuals found on disk')
+    if args.associated_mosaics:  # Code is more readable by keeping these mosaics separate
 
-        if args.regrid:
+        log.info('Checking for models and residuals')
+        make_mosaic.final_check_for_files(input_dir, images, beams)  # This function raises an error and exits if files are not found
+
+        if args.force_regrid:
+            log.info('You have asked for all regridded files to be created by this run, even if they are already on disk')
             make_mosaic.use_montage_for_regridding(
-                input_dir, output_dir, mosaic_type, models, residuals, modelsR, residualsR, outname)
+                input_dir, output_dir, mosaic_type, 'model', models, modelsR, beams, beamsR, outname)
+            make_mosaic.use_montage_for_regridding(
+                input_dir, output_dir, mosaic_type, 'residual', residuals, residualsR, beams, beamsR, outname)
+        elif args.regrid:
+            log.info('Checking for regridded models and residuals')
+            modelsR_dont_exist = check_for_files(output_dir, modelsR)
+            if modelsR_dont_exist:
+                log.info('Regridded models are not all in place, so using montage to create them')
+                make_mosaic.use_montage_for_regridding(
+                    input_dir, output_dir, mosaic_type, 'model', models, modelsR, beams, beamsR, outname)
+            else:
+                log.info('Regridded models are all in place')
+            residualsR_dont_exist = check_for_files(output_dir, residualsR)
+            if residualsR_dont_exist:
+                log.info('Regridded residuals are not all in place, so using montage to create them')
+                make_mosaic.use_montage_for_regridding(
+                    input_dir, output_dir, mosaic_type, 'residual', residuals, residualsR, beams, beamsR, outname)
+            else:
+                log.info('Regridded residuals are all in place')
         else:
             log.info(
-                'Will use regridded models and residuals available on disc'.format(outname))
+                'Will use regridded models and residuals available on disk'.format(outname))
 
         make_mosaic.check_for_regridded_files(output_dir, modelsR, residualsR)
 

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -159,8 +159,8 @@ def main(argv):
 
         make_mosaic.check_for_regridded_files(output_dir, modelsR, residualsR)
 
-        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'model', outname+'_model', modelsR, beamsR, cutoff, models)
-        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'residual', outname+'_residual', residualsR, beamsR, cutoff, residuals)
+        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'model', outname, modelsR, beamsR, cutoff, models)
+        make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'residual', outname, residualsR, beamsR, cutoff, residuals)
 
     # Move the log file to the output directory
     os.system('mv log-make_mosaic.txt '+output_dir+'/')

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -27,8 +27,8 @@ def main(argv):
                         help="The directory that contains the (2D or 3D) images and beams.")
     parser.add_argument("-m", "--mosaic-type",
                         help="State 'continuum' or 'spectral' as the type of (image) mosaic to be made.")
-    parser.add_argument("-a", "--associated-mosaics",
-                        help="Set to 'True' if mosaics of the 'residuals' and 'weights' are also to be made.")
+    parser.add_argument("-a", "--associated-mosaics", action="store_true",
+                        help="Also make mosaics of the associated 'model' and 'residual' .fits files.")
     parser.add_argument("-r", "--regrid", action="store_true",
                         help="Use montage for regridding the images and beams.")
     parser.add_argument("-c", "--cutoff", type=float, default=0.1,
@@ -61,9 +61,14 @@ def main(argv):
         log.error('At least two images must be specified for mosaicking')
         raise ValueError('At least two images must be specified for mosaicking')
 
-    beams = [tt.replace('image.fits', 'pb.fits') for tt in images]
     imagesR = [tt.replace('image.fits', 'imageR.fits') for tt in images]
+    beams = [tt.replace('image.fits', 'pb.fits') for tt in images]
     beamsR = [tt.replace('image.fits', 'pbR.fits') for tt in images]
+    if args.associated_mosaics:
+        log.info('Will generate mosaics based on the input images, their associated models, and their residuals') # Add 'weights' later once I know where it's come from
+        
+    else:
+        log.info('Will generate a mosaic based on the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the "associated_mosaics" parameter enabled.')
 
     for tt in images:
         try:

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -84,19 +84,21 @@ def main(argv):
     else:
         log.info('Will generate a mosaic from the input images. If you would also like mosaics to be made from the associated models and residuals, please re-run with the "associated_mosaics" parameter enabled.')
 
-    for tt in images:
-        try:
-            open(input_dir+'/'+tt)
-        except FileNotFoundError:
-            log.error('File {0:s} does not exist'.format(input_dir+'/'+tt))
-            raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+tt))
+    check_for_files(input_dir, images)
+    #for tt in images:
+    #    try:
+    #        open(input_dir+'/'+tt)
+    #    except FileNotFoundError:
+    #        log.error('File {0:s} does not exist'.format(input_dir+'/'+tt))
+    #        raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+tt))
 
-    for bb in beams:
-        try:
-            open(input_dir+'/'+bb)
-        except FileNotFoundError:
-            log.error('File {0:s} does not exist'.format(input_dir+'/'+bb)) 
-            raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+bb))
+    check_for_files(input_dir, beams)
+    #for bb in beams:
+    #    try:
+    #        open(input_dir+'/'+bb)
+    #    except FileNotFoundError:
+    #        log.error('File {0:s} does not exist'.format(input_dir+'/'+bb)) 
+    #        raise FileNotFoundError('File {0:s} does not exist'.format(input_dir+'/'+bb))
 
     log.info('All images and beams found on disc')
 

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -108,11 +108,15 @@ def main(argv):
             log.info('Regridded images are not all in place, so using montage to create them')
             make_mosaic.use_montage_for_regridding(
                 input_dir, output_dir, mosaic_type, 'image', images, imagesR, beams, beamsR, outname)
+        else:
+            log.info('Regridded images are all in place')
         beamsR_dont_exist = check_for_files(output_dir, beamsR)
         if beamsR_dont_exist:  
             log.info('Regridded beams are not all in place, so using montage to create them')
             make_mosaic.use_montage_for_regridding(
                 input_dir, output_dir, mosaic_type, 'pb', images, imagesR, beams, beamsR, outname)
+        else:
+            log.info('Regridded beams are all in place')
     else:
         log.info(
             'Will use mosaic header {0:s}.hdr and regridded images and beams available on disk'.format(outname))

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -40,16 +40,17 @@ def main(argv):
     parser.add_argument("-a", "--associated-mosaics", action="store_true",
                         help="Also make mosaics of the associated 'model' and 'residual' .fits files.")
     parser.add_argument("-r", "--regrid", action="store_true",
-                        help="Use montage for regridding the images and beams.")
+                        help="Use montage for regridding the images and beams."
+                              "Also the 'model' and 'residual' files, if '--associated-mosaics' has been enabled.")
     parser.add_argument("-c", "--cutoff", type=float, default=0.1,
-                         help="The cutoff in the primary beam to use (assuming a Gaussian at the moment)."
+                        help="The cutoff in the primary beam to use (assuming a Gaussian at the moment)."
                               "E.g. The default of 0.1 means going down to the 10 percent level for each pointing.")
     parser.add_argument("-n", "--name", default="mymosaic",
                         help="The prefix to be used for output files.")
     parser.add_argument("-t", "--target-images", action="append",
-                         help="The filenames of each target/pointing image to be mosaicked. A suffix of 'image.fits' is expected, and this is replaced by 'pb.fits' in order to locate the corresponding beams (which are also required as input).")
+                        help="The filenames of each target/pointing image to be mosaicked. A suffix of 'image.fits' is expected, and this is replaced by 'pb.fits' in order to locate the corresponding beams (which are also required as input).")
     parser.add_argument("-o", "--output",
-                         help="The directory for all output files.")
+                        help="The directory for all output files.")
 
     args = parser.parse_args(argv)
     input_dir = args.input

--- a/MosaicSteward/main.py
+++ b/MosaicSteward/main.py
@@ -164,6 +164,6 @@ def main(argv):
         make_mosaic.make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, 'residual', outname, residualsR, beamsR, cutoff, residuals)
 
     # Move the log file to the output directory
-    os.system('mv log-make__mosaic.txt '+output_dir+'/')
+    os.system('mv log-make_mosaic.txt '+output_dir+'/')
 
     return 0

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -111,24 +111,24 @@ def use_montage_for_regridding(input_dir, output_dir, mosaic_type, images, beams
     return 0
 
 
-def final_check_for_regridded_files(output_dir, imagesR, beamsR):
+def final_check_for_files(directory, imagesR, beamsR):
     # As the regridded files were produced by montage_mosaic, we expect them to be in the output directory
 
     for cc in imagesR:
         try:
-            open(output_dir+'/'+cc)
+            open(directory+'/'+cc)
         except FileNotFoundError:
-            log.error('File {0:s} does not exist'.format(output_dir+'/'+cc))
-            raise FileNotFoundError('File {0:s} does not exist'.format(output_dir+'/'+cc))
+            log.error('File {0:s} does not exist'.format(directory+'/'+cc))
+            raise FileNotFoundError('File {0:s} does not exist'.format(directory+'/'+cc))
 
     for bb in beamsR:
         try:
-            open(output_dir+'/'+bb)
+            open(directory+'/'+bb)
         except FileNotFoundError:
-            log.error('File {0:s} does not exist'.format(output_dir+'/'+bb))
-            raise FileNotFoundError('File {0:s} does not exist'.format(output_dir+'/'+bb))
+            log.error('File {0:s} does not exist'.format(directory+'/'+bb))
+            raise FileNotFoundError('File {0:s} does not exist'.format(directory+'/'+bb))
 
-    log.info('All regridded files found on disc')
+    log.info('All files found on disk')
 
     return 0
 

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -70,7 +70,7 @@ def make_mosaic_header(mosaic_type, t_head):
 # ---------------------------- New/re-structured functions --------------------------------- #
 
 def use_montage_for_regridding(input_dir, output_dir, mosaic_type, image_type, images, imagesR, beams, beamsR, outname):
-                               # image_type should be 'image', 'model', or 'residual'
+                               # image_type should be 'image', 'pb', 'model', or 'residual'
 
     log.info('Running montage tasks to create mosaic header ...')
     # Create an image list
@@ -100,17 +100,17 @@ def use_montage_for_regridding(input_dir, output_dir, mosaic_type, image_type, i
     # Co-add the reprojected images
     #Run(montage_add + ' -p . {0:s}_{1:s}_fields_regrid.tbl {0:s}_{1:s}.hdr {0:s}.fits'.format(outname,image_type))
     
-    if image_type == 'image':  # The original situation, as an 'if' statement so that only one _beams_regrid file is generated
-        log.info('Running montage tasks to regrid beams...')
-        # Reproject the input beams
-        for bb in beams:
-            Run(montage_projection + ' {0:s}/{1:s} {2:s}/{3:s} {2:s}/{4:s}.hdr'.format(
-                input_dir, bb, output_dir, bb.replace('pb.fits', 'pbR.fits'), outname))
-        # Create a reprojected-beams metadata file
-        create_montage_list(beamsR, '{0:s}/{1:s}_beams_regrid'.format(output_dir,outname))
-        Run('mImgtbl -t {0:s}/{1:s}_beams_regrid {0:s} {0:s}/{1:s}_beams_regrid.tbl'.format(output_dir,outname))
-        # Co-add the reprojected beams
-        #Run(montage_add + ' -p . {0:s}_beams_regrid.tbl {0:s}.hdr {0:s}pb.fits'.format(outname))
+    # if image_type == 'image':  # The original situation, as an 'if' statement so that only one _beams_regrid file is generated
+    #     log.info('Running montage tasks to regrid beams...')
+    #     # Reproject the input beams
+    #     for bb in beams:
+    #         Run(montage_projection + ' {0:s}/{1:s} {2:s}/{3:s} {2:s}/{4:s}.hdr'.format(
+    #             input_dir, bb, output_dir, bb.replace('pb.fits', 'pbR.fits'), outname))
+    #     # Create a reprojected-beams metadata file
+    #     create_montage_list(beamsR, '{0:s}/{1:s}_beams_regrid'.format(output_dir,outname))
+    #     Run('mImgtbl -t {0:s}/{1:s}_beams_regrid {0:s} {0:s}/{1:s}_beams_regrid.tbl'.format(output_dir,outname))
+    #     # Co-add the reprojected beams
+    #     #Run(montage_add + ' -p . {0:s}_beams_regrid.tbl {0:s}.hdr {0:s}_pb.fits'.format(outname))
 
     return 0
 

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -75,7 +75,6 @@ def use_montage_for_regridding(input_dir, output_dir, mosaic_type, image_type, i
     log.info('Running montage tasks to create mosaic header ...')
     # Create an image list
     create_montage_list(images, '{0:s}/{1:s}_{2:s}_fields'.format(output_dir,outname,image_type)) 
-    ### CHECK THAT THE .TBL AND .HDR FILES ARE THE SAME, WHATEVER THE IMAGE_TYPE. THEN CAN TAKE THE STRING OUT AGAIN
     #print(sys.stdout)
     Run('mImgtbl -t {0:s}/{1:s}_{2:s}_fields {3:s} {0:s}/{1:s}_{2:s}_fields.tbl'.format(output_dir,outname,image_type,input_dir))
     # Create mosaic header

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -125,6 +125,7 @@ def final_check_for_files(directory, imagesR, beamsR):
         except FileNotFoundError:
             log.error('File {0:s} does not exist'.format(directory+'/'+cc))
             raise FileNotFoundError('File {0:s} does not exist'.format(directory+'/'+cc))
+            sys.exit() ### Added as exiting does not appear be quick enough... not sure what's changed...
 
     for bb in beamsR:
         try:
@@ -132,6 +133,7 @@ def final_check_for_files(directory, imagesR, beamsR):
         except FileNotFoundError:
             log.error('File {0:s} does not exist'.format(directory+'/'+bb))
             raise FileNotFoundError('File {0:s} does not exist'.format(directory+'/'+bb))
+            sys.exit()
 
     log.info('All files found on disk')
 

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -141,7 +141,7 @@ def final_check_for_files(directory, imagesR, beamsR):
 def make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, image_type, outname, imagesR, beamsR, cutoff, images):
                                 # image_type should be 'image', 'model', or 'residual'
 
-    log.info("Mosaicking an '{0:s}' mosaic...".format(image_type))
+    log.info("Creating an '{0:s}' mosaic...".format(image_type))
     moshead = [jj.strip().replace(' ', '').split('=')
             for jj in open('{0:s}/{1:s}_{2:s}.hdr'.format(output_dir,outname,image_type)).readlines()]
     if ['END'] in moshead:

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -143,7 +143,7 @@ def final_check_for_files(directory, imagesR, beamsR):
 def make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, image_type, outname, imagesR, beamsR, cutoff, images):
                                 # image_type should be 'image', 'model', or 'residual'
 
-    log.info("Creating an '{0:s}' mosaic...".format(image_type))
+    log.info("Creating a mosaic from '{0:s}' files...".format(image_type))
     moshead = [jj.strip().replace(' ', '').split('=')
             for jj in open('{0:s}/{1:s}_{2:s}.hdr'.format(output_dir,outname,image_type)).readlines()]
     if ['END'] in moshead:

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -74,11 +74,12 @@ def use_montage_for_regridding(input_dir, output_dir, mosaic_type, image_type, i
 
     log.info('Running montage tasks to create mosaic header ...')
     # Create an image list
-    create_montage_list(images, '{0:s}/{1:s}_fields'.format(output_dir,outname))
+    create_montage_list(images, '{0:s}/{1:s}_{2:s}_fields'.format(output_dir,outname,image_type)) 
+    ### CHECK THAT THE .TBL AND .HDR FILES ARE THE SAME, WHATEVER THE IMAGE_TYPE. THEN CAN TAKE THE STRING OUT AGAIN
     #print(sys.stdout)
-    Run('mImgtbl -t {0:s}/{1:s}_fields {2:s} {0:s}/{1:s}_fields.tbl'.format(output_dir,outname,input_dir))
+    Run('mImgtbl -t {0:s}/{1:s}_{2:s}_fields {3:s} {0:s}/{1:s}_{2:s}_fields.tbl'.format(output_dir,outname,image_type,input_dir))
     # Create mosaic header
-    Run('mMakeHdr {0:s}/{1:s}_fields.tbl {0:s}/{1:s}.hdr'.format(output_dir,outname))
+    Run('mMakeHdr {0:s}/{1:s}_{2:s}_fields.tbl {0:s}/{1:s}_{2:s}.hdr'.format(output_dir,outname,image_type))
     
     # Which montage program is used for regridding depends on whether the image is 2D or 3D
     if mosaic_type == 'spectral':
@@ -91,13 +92,13 @@ def use_montage_for_regridding(input_dir, output_dir, mosaic_type, image_type, i
     log.info('Running montage tasks to regrid files ...')
     # Reproject the input images
     for cc in images:
-        Run(montage_projection + ' {0:s}/{1:s} {2:s}/{3:s} {2:s}/{4:s}.hdr'.format(
-            input_dir, cc, output_dir, cc.replace(image_type+'.fits', image_type+'R.fits'), outname))
+        Run(montage_projection + ' {0:s}/{1:s} {2:s}/{3:s} {2:s}/{4:s}_{5:s}.hdr'.format(
+            input_dir, cc, output_dir, cc.replace(image_type+'.fits', image_type+'R.fits'), outname, image_type))
     # Create a reprojected-image metadata file
-    create_montage_list(imagesR, '{0:s}/{1:s}_fields_regrid'.format(output_dir,outname))
-    Run('mImgtbl -d -t {0:s}/{1:s}_fields_regrid {0:s} {0:s}/{1:s}_fields_regrid.tbl'.format(output_dir,outname)) # '-d' flag added to aid de-bugging
+    create_montage_list(imagesR, '{0:s}/{1:s}_{2:s}_fields_regrid'.format(output_dir,outname, image_type))
+    Run('mImgtbl -d -t {0:s}/{1:s}_{2:s}_fields_regrid {0:s} {0:s}/{1:s}_{2:s}_fields_regrid.tbl'.format(output_dir,outname,image_type)) # '-d' flag added to aid de-bugging
     # Co-add the reprojected images
-    #Run(montage_add + ' -p . {0:s}_fields_regrid.tbl {0:s}.hdr {0:s}.fits'.format(outname))
+    #Run(montage_add + ' -p . {0:s}_{1:s}_fields_regrid.tbl {0:s}_{1:s}.hdr {0:s}.fits'.format(outname,image_type))
     
     if image_type == 'image':  # The original situation, as an 'if' statement so that only one _beams_regrid file is generated
         log.info('Running montage tasks to regrid beams...')

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -141,7 +141,7 @@ def final_check_for_files(directory, imagesR, beamsR):
 def make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, image_type, outname, imagesR, beamsR, cutoff, images):
                                 # image_type should be 'image', 'model', or 'residual'
 
-    log.info('Mosaicking ...')
+    log.info("Mosaicking an '{0:s}' mosaic...".format(image_type))
     moshead = [jj.strip().replace(' ', '').split('=')
             for jj in open('{0:s}/{1:s}_{2:s}.hdr'.format(output_dir,outname,image_type)).readlines()]
     if ['END'] in moshead:

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -86,7 +86,7 @@ def use_montage_for_regridding(input_dir, output_dir, mosaic_type, images, beams
         montage_projection = 'mProject'
         montage_add = 'mAdd'
 
-    log.info('Running montage tasks to regrid the input images ...')
+    log.info('Running montage tasks to regrid files ...')
     # Reproject the input images
     for cc in images:
         Run(montage_projection + ' {0:s}/{1:s} {2:s}/{3:s} {2:s}/{4:s}.hdr'.format(
@@ -97,7 +97,7 @@ def use_montage_for_regridding(input_dir, output_dir, mosaic_type, images, beams
     # Co-add the reprojected images
     #Run(montage_add + ' -p . {0:s}_fields_regrid.tbl {0:s}.hdr {0:s}.fits'.format(outname))
     
-    log.info('Running montage tasks to regrid the input beams ...')
+    log.info('Running montage tasks to regrid input files ...')
     # Reproject the input beams
     for bb in beams:
         Run(montage_projection + ' {0:s}/{1:s} {2:s}/{3:s} {2:s}/{4:s}.hdr'.format(
@@ -128,7 +128,7 @@ def check_for_regridded_files(output_dir, imagesR, beamsR):
             log.error('File {0:s} does not exist'.format(output_dir+'/'+bb))
             raise FileNotFoundError('File {0:s} does not exist'.format(output_dir+'/'+bb))
 
-    log.info('All regridded images and beams found on disc')
+    log.info('All regridded files found on disc')
 
     return 0
 

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -139,10 +139,11 @@ def final_check_for_files(directory, imagesR, beamsR):
 
 
 def make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, image_type, outname, imagesR, beamsR, cutoff, images):
+                                # image_type should be 'image', 'model', or 'residual'
 
     log.info('Mosaicking ...')
     moshead = [jj.strip().replace(' ', '').split('=')
-            for jj in open('{0:s}/{1:s}.hdr'.format(output_dir,outname)).readlines()]
+            for jj in open('{0:s}/{1:s}_{2:s}.hdr'.format(output_dir,outname,image_type)).readlines()]
     if ['END'] in moshead:
         del(moshead[moshead.index(['END'])])
     moshead = {k: v for (k, v) in moshead}   # Creating a dictionary, where 'k' stands for 'keyword' and 'v' stands for 'value'
@@ -186,7 +187,7 @@ def make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, image_type, 
         f = fits.open(input_dir+'/'+images[0]) 
         zhead = f[0].header
         moshead['ctype3'] = zhead['ctype3']
-    fits.writeto('{0:s}/{1:s}.fits'.format(output_dir,outname), mos_array /
+    fits.writeto('{0:s}/{1:s}_{2:s}.fits'.format(output_dir,outname,image_type), mos_array /
                  norm_array, overwrite=True, header=moshead)
 
     if image_type == 'image':  # Only want one copy of the _noise and _weights mosaics to be produced
@@ -194,9 +195,9 @@ def make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, image_type, 
                      np.sqrt(norm_array), overwrite=True, header=moshead)
         fits.writeto('{0:s}/{1:s}_weights.fits'.format(output_dir,outname),
                      np.sqrt(norm_array), overwrite=True, header=moshead)
-        log.info('The following mosaic FITS were written to disc: {0:s}.fits {0:s}_noise.fits {0:s}_weights.fits'.format(outname))
+        log.info('The following mosaic FITS were written to disc: {0:s}_{1:s}.fits {0:s}_noise.fits {0:s}_weights.fits'.format(outname,image_type))
     else:  # i.e. when making a mosaic of the 'model' or 'residual' .fits files
-        log.info('The following mosaic FITS was written to disc: {0:s}.fits'.format(outname))
+        log.info('The following mosaic FITS was written to disc: {0:s}_{1:s}.fits'.format(outname,image_type))
     
     log.info('Mosaicking completed')
 

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -111,7 +111,7 @@ def use_montage_for_regridding(input_dir, output_dir, mosaic_type, images, beams
     return 0
 
 
-def check_for_regridded_files(output_dir, imagesR, beamsR):
+def final_check_for_regridded_files(output_dir, imagesR, beamsR):
     # As the regridded files were produced by montage_mosaic, we expect them to be in the output directory
 
     for cc in imagesR:

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -69,7 +69,9 @@ def make_mosaic_header(mosaic_type, t_head):
 
 # ---------------------------- New/re-structured functions --------------------------------- #
 
-def use_montage_for_regridding(input_dir, output_dir, mosaic_type, images, beams, imagesR, beamsR, outname):
+def use_montage_for_regridding(input_dir, output_dir, mosaic_type, image_type, images, imagesR, outname):
+                               # image_type should be 'image', 'pb', 'model', or 'residual'
+
     log.info('Running montage tasks to create mosaic header ...')
     # Create an image list
     create_montage_list(images, '{0:s}/{1:s}_fields'.format(output_dir,outname))
@@ -90,7 +92,7 @@ def use_montage_for_regridding(input_dir, output_dir, mosaic_type, images, beams
     # Reproject the input images
     for cc in images:
         Run(montage_projection + ' {0:s}/{1:s} {2:s}/{3:s} {2:s}/{4:s}.hdr'.format(
-            input_dir, cc, output_dir, cc.replace('image.fits', 'imageR.fits'), outname))
+            input_dir, cc, output_dir, cc.replace(image_type+'.fits', image_type+'R.fits'), outname))
     # Create a reprojected-image metadata file
     create_montage_list(imagesR, '{0:s}/{1:s}_fields_regrid'.format(output_dir,outname))
     Run('mImgtbl -d -t {0:s}/{1:s}_fields_regrid {0:s} {0:s}/{1:s}_fields_regrid.tbl'.format(output_dir,outname)) # '-d' flag added to aid de-bugging

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -69,8 +69,8 @@ def make_mosaic_header(mosaic_type, t_head):
 
 # ---------------------------- New/re-structured functions --------------------------------- #
 
-def use_montage_for_regridding(input_dir, output_dir, mosaic_type, image_type, images, imagesR, outname):
-                               # image_type should be 'image', 'pb', 'model', or 'residual'
+def use_montage_for_regridding(input_dir, output_dir, mosaic_type, image_type, images, imagesR, beams, beamsR, outname):
+                               # image_type should be 'image', 'model', or 'residual'
 
     log.info('Running montage tasks to create mosaic header ...')
     # Create an image list
@@ -99,16 +99,17 @@ def use_montage_for_regridding(input_dir, output_dir, mosaic_type, image_type, i
     # Co-add the reprojected images
     #Run(montage_add + ' -p . {0:s}_fields_regrid.tbl {0:s}.hdr {0:s}.fits'.format(outname))
     
-    log.info('Running montage tasks to regrid input files ...')
-    # Reproject the input beams
-    for bb in beams:
-        Run(montage_projection + ' {0:s}/{1:s} {2:s}/{3:s} {2:s}/{4:s}.hdr'.format(
-            input_dir, bb, output_dir, bb.replace('pb.fits', 'pbR.fits'), outname))
-    # Create a reprojected-beams metadata file
-    create_montage_list(beamsR, '{0:s}/{1:s}_beams_regrid'.format(output_dir,outname))
-    Run('mImgtbl -t {0:s}/{1:s}_beams_regrid {0:s} {0:s}/{1:s}_beams_regrid.tbl'.format(output_dir,outname))
-    # Co-add the reprojected beams
-    #Run(montage_add + ' -p . {0:s}_beams_regrid.tbl {0:s}.hdr {0:s}pb.fits'.format(outname))
+    if image_type == 'image':  # The original situation, as an 'if' statement so that only one _beams_regrid file is generated
+        log.info('Running montage tasks to regrid beams...')
+        # Reproject the input beams
+        for bb in beams:
+            Run(montage_projection + ' {0:s}/{1:s} {2:s}/{3:s} {2:s}/{4:s}.hdr'.format(
+                input_dir, bb, output_dir, bb.replace('pb.fits', 'pbR.fits'), outname))
+        # Create a reprojected-beams metadata file
+        create_montage_list(beamsR, '{0:s}/{1:s}_beams_regrid'.format(output_dir,outname))
+        Run('mImgtbl -t {0:s}/{1:s}_beams_regrid {0:s} {0:s}/{1:s}_beams_regrid.tbl'.format(output_dir,outname))
+        # Co-add the reprojected beams
+        #Run(montage_add + ' -p . {0:s}_beams_regrid.tbl {0:s}.hdr {0:s}pb.fits'.format(outname))
 
     return 0
 

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -125,7 +125,7 @@ def final_check_for_files(directory, imagesR, beamsR):
         except FileNotFoundError:
             log.error('File {0:s} does not exist'.format(directory+'/'+cc))
             raise FileNotFoundError('File {0:s} does not exist'.format(directory+'/'+cc))
-            sys.exit() ### Added as exiting does not appear be quick enough... not sure what's changed...
+            #sys.exit() ### Added as exiting does not appear be quick enough... not sure what's changed...
 
     for bb in beamsR:
         try:
@@ -133,7 +133,7 @@ def final_check_for_files(directory, imagesR, beamsR):
         except FileNotFoundError:
             log.error('File {0:s} does not exist'.format(directory+'/'+bb))
             raise FileNotFoundError('File {0:s} does not exist'.format(directory+'/'+bb))
-            sys.exit()
+            #sys.exit()
 
     log.info('All files found on disk')
 

--- a/MosaicSteward/make_mosaic.py
+++ b/MosaicSteward/make_mosaic.py
@@ -197,9 +197,9 @@ def make_mosaic_using_beam_info(input_dir, output_dir, mosaic_type, image_type, 
                      np.sqrt(norm_array), overwrite=True, header=moshead)
         fits.writeto('{0:s}/{1:s}_weights.fits'.format(output_dir,outname),
                      np.sqrt(norm_array), overwrite=True, header=moshead)
-        log.info('The following mosaic FITS were written to disc: {0:s}_{1:s}.fits {0:s}_noise.fits {0:s}_weights.fits'.format(outname,image_type))
+        log.info('The following mosaic FITS were written to disk: {0:s}_{1:s}.fits {0:s}_noise.fits {0:s}_weights.fits'.format(outname,image_type))
     else:  # i.e. when making a mosaic of the 'model' or 'residual' .fits files
-        log.info('The following mosaic FITS was written to disc: {0:s}_{1:s}.fits'.format(outname,image_type))
+        log.info('The following mosaic FITS was written to disk: {0:s}_{1:s}.fits'.format(outname,image_type))
     
     log.info('Mosaicking completed')
 


### PR DESCRIPTION
[Sorry for the late hour, but I don't understand Travis and this seems fine now, unlike a moment ago...!]

This is a PR to address #8, with an optional '--associated-mosaics' argument to allow mosaics to be created from the 'model' and 'residual' files, as well as the 'image' files.

@paoloserra, please could you test it, with a command like the following:

```
MosaicSteward --mosaic-type spectral --regrid --cutoff 0.25 --name fromPaolo --input user_input --target-images j0831-5517-ska_HI.image.fits --target-images j0836-5552-ska_HI.image.fits --target-images j0839-5517-ska_HI.image.fits --output user_output --associated-mosaics
```

Other changes:
* ```--domontage``` is now ```--regrid``` as this is a better descriptor.
* If ```--regrid``` is not enabled, MosaicSteward will check for regridded files and exit if it can't find them.
* If ```--regrid``` is enabled, MosaicSteward will check for regridded files and create them if it can't find them.
* "But Sarah, what if I don't want it to use existing regridded files but newly-created ones instead?" "Ah ha, well that's where you should use the new argument: ```--force-regrid``` "
* ~~Regretting~~ Regridding of images and beams is now done separately so that (hopefully) they can later be distributed more easily. 
* The main mosaic now ends with _image.fits (and is written alongside _noise.fits and _weights.fits, as before).
* The associated mosaics are then _model.fits and _residual.fits.

@SpheMakh, please could you check that the FileNotFoundError is being raised correctly? I thought we had the exceptions working nicely before (i.e. over a year ago) but now I'm getting messy-looking Traceback messages when it's supposed to simply state the name of the missing file and then exit cleanly :( 

Thanks x